### PR TITLE
Avoid using deprecated feature.

### DIFF
--- a/Formula/llvm-5.0.rb
+++ b/Formula/llvm-5.0.rb
@@ -199,7 +199,7 @@ class Llvm50 < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Extra tools are installed in #{opt_share}/clang-#{ver}
 
     To link to libc++, something like the following is required:


### PR DESCRIPTION
The llvm 5 formula does not work with current `brew`. `brew install` fails with

    Warning: Calling <<-EOS.undent is deprecated!
    Use <<~EOS instead.

The formula for llvm 6 already uses `<<~EOS` instead of `<<-EOS.undent`.